### PR TITLE
お知らせ一覧を直す

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,9 +15,12 @@ const Home = async () => {
         />
       </div>
       <div className={styles.contentContainer}>
+        {/* お知らせ一覧 */}
         <Section sectionType="bottomLine" text="お知らせ">
           <Posts />
         </Section>
+
+        {/* 部活紹介 */}
         <Section sectionType="bottomLine" text="部活紹介">
           <Section sectionType="leftLine" text="概要">
             <p>

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -2,7 +2,7 @@
 import { Pagination } from '@/components/features/Pagination'
 import { Post } from '@/components/features/Post'
 import { getContentsApi } from '@/feature/cms/hooks/MicroCmsContents'
-import type { PostsType, WorksType } from '@/libs/cms/types/MicroCmsType'
+import type { PostsType } from '@/libs/cms/types/MicroCmsType'
 import { createLoadingPosts } from '@/libs/post/createPostDummy'
 import { type JSX, useEffect, useState } from 'react'
 import styles from './page.module.scss'
@@ -25,8 +25,9 @@ export default function Posts() {
           id={content.id}
           title={content.title}
           date={content.date}
-          image={content.image}
+          mainImage={content.mainImage}
           description={content.description}
+          contents={content.contents}
         />
       )
     })
@@ -38,28 +39,16 @@ export default function Posts() {
   useEffect(() => {
     const fetchContents = async () => {
       const contents = await getContentsApi({
-        endpoint: 'works',
+        endpoint: 'posts',
         limit: CONTENTS_PER_PAGE,
         offset: page * CONTENTS_PER_PAGE,
       })
-      const json = contents.contents as WorksType[]
+      const contentsList = contents.contents as PostsType[]
       if (totalCount === 0) setTotalCount(contents.totalCount)
-      const convertedContents = json.map((content: WorksType) => convertContents(content))
-      setContents(convertedContents)
+      setContents(contentsList)
     }
     if (!postElement.has(page) || postElement.get(page)?.length === 0) fetchContents()
   }, [page])
-
-  const convertContents = (contents: WorksType): PostsType => {
-    const convertedContents: PostsType = {
-      id: contents.id,
-      title: contents.title,
-      date: contents.date,
-      image: contents.mainImage,
-      description: contents.description,
-    }
-    return convertedContents
-  }
 
   return (
     <div className={styles.container}>

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -54,7 +54,7 @@ export default function Posts() {
     <div className={styles.container}>
       {!postElement.get(page) || postElement.get(page)?.length === 0 ? DUMMY_ELEMENT : postElement.get(page)}
       <Pagination
-        total={totalCount / CONTENTS_PER_PAGE}
+        total={Math.ceil(totalCount / CONTENTS_PER_PAGE)}
         activePages={page + 1}
         onChange={(page) => {
           setPage(page - 1)

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -10,8 +10,8 @@ import styles from './page.module.scss'
 export default function Posts() {
   const [contents, setContents] = useState<PostsType[]>([])
   const [postElement, setPostElement] = useState(new Map<number, JSX.Element[]>())
-  const [page, setPage] = useState(0)
-  const [totalCount, setTotalCount] = useState(0)
+  const [page, setPage] = useState<number>(0)
+  const [totalCount, setTotalCount] = useState<number>(0)
   const CONTENTS_PER_PAGE = 5
   const DUMMY_ELEMENT = createLoadingPosts(CONTENTS_PER_PAGE)
 

--- a/src/components/features/Post/index.module.scss
+++ b/src/components/features/Post/index.module.scss
@@ -22,12 +22,12 @@
         margin-left: 4px;
 
         .date {
-            font-size: 10px;
+            font-size: 12px;
             font-weight: 700;
         }
 
-        .description {
-            font-size: 12px;
+        .title {
+            font-size: 16px;
             line-height: 150%;
         }
     }

--- a/src/components/features/Post/index.tsx
+++ b/src/components/features/Post/index.tsx
@@ -14,10 +14,10 @@ export const Post = (props: Props) => {
   const formattedDate = dayjs(props.date).format('YYYY/MM/DD')
   return (
     <Link className={`${styles.container} ${containerStyle}`} href={`/posts/${props.id}`}>
-      <img className={styles.img} src={props.image.url} alt={props.id} />
+      {props.mainImage && <img className={styles.img} src={props.mainImage.url} alt={props.id} />}
       <div className={styles.textContainer}>
         <p className={styles.date}>{formattedDate}</p>
-        <p className={styles.description}>{props.description}</p>
+        <p className={styles.title}>{props.title}</p>
       </div>
     </Link>
   )

--- a/src/components/features/Posts/index.tsx
+++ b/src/components/features/Posts/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { getContentsApi } from '@/feature/cms/hooks/MicroCmsContents'
-import type { PostsType, WorksType } from '@/libs/cms/types/MicroCmsType'
+import type { PostsType } from '@/libs/cms/types/MicroCmsType'
 import { createLoadingPosts } from '@/libs/post/createPostDummy'
 import { type JSX, useEffect, useRef, useState } from 'react'
 import { LinkButton } from '../Button/LinkButton'
@@ -16,10 +16,9 @@ export const Posts = () => {
   useEffect(() => {
     if (!isFirstRender.current) return
     const fetchContents = async () => {
-      const contents = await getContentsApi({ endpoint: 'works', limit: 5 })
-      const json = contents.contents as WorksType[]
-      const convertedContents = json.map((content: WorksType) => convertContents(content))
-      const Element = convertedContents.map((content, index) => {
+      const contents = await getContentsApi({ endpoint: 'posts', limit: 5 })
+      const contentsList = contents.contents as PostsType[]
+      const Element = contentsList.map((content, index) => {
         return (
           <Post
             key={content.id}
@@ -27,8 +26,9 @@ export const Posts = () => {
             id={content.id}
             title={content.title}
             date={content.date}
-            image={content.image}
+            mainImage={content.mainImage}
             description={content.description}
+            contents={content.contents}
           />
         )
       })
@@ -37,17 +37,6 @@ export const Posts = () => {
     isFirstRender.current = false
     fetchContents()
   }, [])
-
-  const convertContents = (contents: WorksType): PostsType => {
-    const convertedContents: PostsType = {
-      id: contents.id,
-      title: contents.title,
-      date: contents.date,
-      image: contents.mainImage,
-      description: contents.description,
-    }
-    return convertedContents
-  }
 
   return (
     <div className={styles.container}>

--- a/src/libs/cms/types/MicroCmsType.ts
+++ b/src/libs/cms/types/MicroCmsType.ts
@@ -15,8 +15,9 @@ export type PostsType = {
   id: string
   title: string
   date: Date
-  image: { url: string; height: number; width: number }
+  mainImage: { url: string; height: number; width: number }
   description: string
+  contents: string
 }
 
 export type MicroCmsType = {

--- a/src/libs/post/createPostDummy.tsx
+++ b/src/libs/post/createPostDummy.tsx
@@ -12,12 +12,13 @@ export const createDummyPosts = (amount: number) => {
         id="Dummy"
         title=""
         date={new Date()}
-        image={{
+        mainImage={{
           url: 'testImgs/mock1.png',
           width: 1920,
           height: 1080,
         }}
         description=""
+        contents={''}
       />
     )
   }


### PR DESCRIPTION
<!-- テンプレに沿ってPRを出しましょう
コメント文は出力されないから消さなくてOK -->

# 概要
- #88 

今まではお知らせを仮置き(workから変換)していたが、それを本当のお知らせが入るように修正
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/52891f51-115f-4033-b6ec-28c68de87725" />
<img width="1078" alt="image" src="https://github.com/user-attachments/assets/f51d97c7-1f7b-4ed9-bf65-8c752d85d97c" />
@mm1007 ↑ ページネーション助けてください

## 変更内容
convertContentsの削除
postsTypeの編集
その他色々

<!-- 具体的に何を変更したのか、簡単に箇条書きで記述 -->
<!-- 画面の変更がある場合、スクショも添付 -->
