### PR TITLE
フッターのモバイル用スタイル変更

### DIFF
--- a/src/components/Footer/index.module.scss
+++ b/src/components/Footer/index.module.scss
@@ -3,6 +3,10 @@
     padding: 30px 70px;
     font-weight: 700;
 
+    @media (max-width: 768px) {
+        padding: 30px 0px;
+      }
+
     .container{
         max-width: 1400px;
         margin: 0 auto;
@@ -29,7 +33,7 @@
         @media (max-width: 768px) {
             flex-direction: column; // モバイル用に縦並びに変更
             text-align: center;
-        }
+          }
 
         .column{
             flex: 1;


### PR DESCRIPTION
<!-- テンプレに沿ってPRを出しましょう
コメント文は出力されないから消さなくてOK -->

# 概要
モバイル用のスタイルを変更しました

## 変更内容
モバイルで見た場合左に寄るようにscssを変更しました
<img width="328" alt="image" src="https://github.com/user-attachments/assets/b22adf64-4b8a-481c-9a9f-82b44af10ced" />


<!-- 具体的に何を変更したのか、簡単に箇条書きで記述 -->
<!-- 画面の変更がある場合、スクショも添付 -->
