### PR TITLE
notionに飛ぶリンクの追加

### DIFF
--- a/src/app/index.module.scss
+++ b/src/app/index.module.scss
@@ -13,4 +13,9 @@
       padding-right: 16px;
     }
   }
+
+  .link{
+    color: var(--text-link);
+    text-decoration: underline;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,10 @@ const Home = async () => {
             <ul style={{ listStyleType: 'disc', listStylePosition: 'inside' }}>
               <li>
                 勉強会：初心者向けのプログラミング勉強会を定期的に開催（
-                <a href="https://www.notion.so/1dc87bcd6fe1800da6beecf2bd6bcc70" className={styles.link}>
+                <a
+                  href="https://winter-rock-f72.notion.site/1dc87bcd6fe1800da6beecf2bd6bcc70?pvs=4"
+                  className={styles.link}
+                >
                   勉強資料
                 </a>
                 ）

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,6 +28,13 @@ const Home = async () => {
           </Section>
           <Section sectionType="leftLine" text="活動内容">
             <ul style={{ listStyleType: 'disc', listStylePosition: 'inside' }}>
+              <li>
+                勉強会：初心者向けのプログラミング勉強会を定期的に開催（
+                <a href="https://www.notion.so/1dc87bcd6fe1800da6beecf2bd6bcc70" className={styles.link}>
+                  勉強資料
+                </a>
+                ）
+              </li>
               <li>Web開発：学校紹介サイトや部活管理システムの開発</li>
               <li>アプリ制作：便利なツールアプリやゲームの制作</li>
               <li>イベントへの参加：プログラミングコンテストやハッカソンへの参加</li>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -29,6 +29,7 @@ export const Footer = (props: Props) => {
           <div className={styles.column}>
             <Splitter text="部員向け">
               <Item url="/schedule" text="予定" size="default" />
+              <Item url="https://www.notion.so/1dc87bcd6fe1800da6beecf2bd6bcc70" text="勉強資料" size="default" />{' '}
               <Item url="/posts" text="お知らせ" size="default" />
               <Item url="https://procon-absence-form.vercel.app/" text="欠席連絡フォーム" size="default" />
             </Splitter>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -29,7 +29,7 @@ export const Footer = (props: Props) => {
           <div className={styles.column}>
             <Splitter text="部員向け">
               <Item url="/schedule" text="予定" size="default" />
-              <Item url="https://www.notion.so/1dc87bcd6fe1800da6beecf2bd6bcc70" text="勉強資料" size="default" />{' '}
+              <Item url="https://www.notion.so/1dc87bcd6fe1800da6beecf2bd6bcc70" text="勉強資料" size="default" />
               <Item url="/posts" text="お知らせ" size="default" />
               <Item url="https://procon-absence-form.vercel.app/" text="欠席連絡フォーム" size="default" />
             </Splitter>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -29,7 +29,11 @@ export const Footer = (props: Props) => {
           <div className={styles.column}>
             <Splitter text="部員向け">
               <Item url="/schedule" text="予定" size="default" />
-              <Item url="https://www.notion.so/1dc87bcd6fe1800da6beecf2bd6bcc70" text="勉強資料" size="default" />
+              <Item
+                url="https://winter-rock-f72.notion.site/1dc87bcd6fe1800da6beecf2bd6bcc70?pvs=4"
+                text="勉強資料"
+                size="default"
+              />
               <Item url="/posts" text="お知らせ" size="default" />
               <Item url="https://procon-absence-form.vercel.app/" text="欠席連絡フォーム" size="default" />
             </Splitter>

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -21,7 +21,11 @@ export const SideBar = ({ className, style }: Props) => {
         </Splitter>
         <Splitter text="部員向け">
           <Item url="/schedule" text="予定" size="default" />
-          <Item url="https://www.notion.so/1dc87bcd6fe1800da6beecf2bd6bcc70" text="勉強資料" size="default" />
+          <Item
+            url="https://winter-rock-f72.notion.site/1dc87bcd6fe1800da6beecf2bd6bcc70?pvs=4"
+            text="勉強資料"
+            size="default"
+          />
           <Item url="/posts" text="お知らせ" size="default" />
           <Item url="https://procon-absence-form.vercel.app/" text="欠席連絡フォーム" size="default" />
         </Splitter>

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -21,6 +21,7 @@ export const SideBar = ({ className, style }: Props) => {
         </Splitter>
         <Splitter text="部員向け">
           <Item url="/schedule" text="予定" size="default" />
+          <Item url="https://www.notion.so/1dc87bcd6fe1800da6beecf2bd6bcc70" text="勉強資料" size="default" />
           <Item url="/posts" text="お知らせ" size="default" />
           <Item url="https://procon-absence-form.vercel.app/" text="欠席連絡フォーム" size="default" />
         </Splitter>


### PR DESCRIPTION
<!-- テンプレに沿ってPRを出しましょう
コメント文は出力されないから消さなくてOK -->

# 概要
notionにおいてある勉強資料に飛べるようにしました

## 変更内容
![image](https://github.com/user-attachments/assets/919a5001-105d-45cb-b763-d3b464b2302d)
![image](https://github.com/user-attachments/assets/24b517f5-b024-4075-8317-23697c66e1f0)
![image](https://github.com/user-attachments/assets/a92e1363-ae2a-4106-9cb5-b911adfe98b8)

<!-- 具体的に何を変更したのか、簡単に箇条書きで記述 -->
<!-- 画面の変更がある場合、スクショも添付 -->
